### PR TITLE
Tune logistic_l, break line endings

### DIFF
--- a/data/CCH_parameters.csv
+++ b/data/CCH_parameters.csv
@@ -15,7 +15,7 @@
 14,14,14,14,recovery_days,14,gamma,9.833457434,1.642265575,Days from infection to recovery
 15,15,15,15,logistic_k,1,gamma,4.018953794,0.22738215,logistic growth rate
 16,16,16,16,logistic_x0,14,gamma,6.407435434,2.859728136,logistic days from beginning of time series to middle of logistic
-17,17,17,17,logistic_L,0.5,beta,3.41910472,2.551923087,logistic depth of social distancing
+17,17,17,17,logistic_L,0.5,beta,20.94604732,39.40072537,logistic depth of social distancing
 18,17,17,17,nu,0,constant,0.831874664,0.902383776,Networked contact structure power-law exponent
 18,17,17,17,beta,0.25,beta,5,10,SEIR beta parameter (force of infection)
 18,17,17,17,hosp_capacity,,constant,,,Hospital Bed Capacity

--- a/data/Downtown_parameters.csv
+++ b/data/Downtown_parameters.csv
@@ -15,7 +15,7 @@
 14,14,14,14,recovery_days,14,gamma,9.833457434,1.642265575,Days from infection to recovery
 15,15,15,15,logistic_k,1,gamma,4.018953794,0.22738215,logistic growth rate
 16,16,16,16,logistic_x0,14,gamma,6.407435434,2.859728136,logistic days from beginning of time series to middle of logistic
-17,17,17,17,logistic_L,0.5,beta,3.41910472,2.551923087,logistic depth of social distancing
+17,17,17,17,logistic_L,0.5,beta,20.94604732,39.40072537,logistic depth of social distancing
 18,17,17,17,nu,0,constant,0.831874664,0.902383776,Networked contact structure power-law exponent
 18,17,17,17,beta,0.25,beta,5,10,SEIR beta parameter (force of infection)
 18,17,17,17,hosp_capacity,,constant,,,Hospital Bed Capacity

--- a/data/LGH_parameters.csv
+++ b/data/LGH_parameters.csv
@@ -15,7 +15,7 @@
 14,14,14,14,recovery_days,14,gamma,9.833457434,1.642265575,Days from infection to recovery
 15,15,15,15,logistic_k,1,gamma,4.018953794,0.22738215,logistic growth rate
 16,16,16,16,logistic_x0,14,gamma,6.407435434,2.859728136,logistic days from beginning of time series to middle of logistic
-17,17,17,17,logistic_L,0.5,beta,3.41910472,2.551923087,logistic depth of social distancing
+17,17,17,17,logistic_L,0.5,beta,20.94604732,39.40072537,logistic depth of social distancing
 18,17,17,17,nu,0,constant,0.831874664,0.902383776,Networked contact structure power-law exponent
 18,17,17,17,beta,0.25,beta,5,10,SEIR beta parameter (force of infection)
 18,17,17,17,hosp_capacity,,constant,,,Hospital Bed Capacity

--- a/data/MCP_parameters.csv
+++ b/data/MCP_parameters.csv
@@ -15,7 +15,7 @@
 14,14,14,14,recovery_days,14,gamma,9.833457434,1.642265575,Days from infection to recovery
 15,15,15,15,logistic_k,1,gamma,4.018953794,0.22738215,logistic growth rate
 16,16,16,16,logistic_x0,14,gamma,6.407435434,2.859728136,logistic days from beginning of time series to middle of logistic
-17,17,17,17,logistic_L,0.5,beta,3.41910472,2.551923087,logistic depth of social distancing
+17,17,17,17,logistic_L,0.5,beta,20.94604732,39.40072537,logistic depth of social distancing
 18,17,17,17,nu,0,constant,0.831874664,0.902383776,Networked contact structure power-law exponent
 18,17,17,17,beta,0.25,beta,5,10,SEIR beta parameter (force of infection)
 18,17,17,17,hosp_capacity,,constant,,,Hospital Bed Capacity


### PR DESCRIPTION
The raw diff showed line endings on the lines I edited in the csvs, but they don't appear in the web diff.