### PR TITLE
added automatic scaling of spline terms based on numbers of days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ output/*
 !output/
 *.egg-info
 drafts/
+*~
+out_misc/

--- a/_01_GOF_sims.py
+++ b/_01_GOF_sims.py
@@ -473,12 +473,13 @@ def main():
     # also add the number of observations, as i'll need this for evaluating the knots
     # finally, estimate the scaling factors for the design matrix
     if flexible_beta == True:
+        beta_spline_power = int(params.loc[params.param == "beta_spline_power", 'base'])
         beta_splines = pd.DataFrame([{
             "param": f"beta_spline_coef_{i}",
             'base':0,
             "distribution":"norm",
             "p1":0,
-            "p2":float(params.p2.loc[params.param == 'beta_spline_prior']),
+            "p2":float(params.p2.loc[params.param == 'beta_spline_prior']**beta_spline_power),
             'description':'spile term for beta'
             } for i in range(int(params.base.loc[params.param == "beta_spline_dimension"]))])
         nobsd = pd.DataFrame(dict(param = 'nobs', base = nobs, 
@@ -489,7 +490,6 @@ def main():
         # create the design matrix in order to compute the scaling factors
         # this is critical to make the prior on design matrix flexibility invariant to the scaling of the features
         beta_k = int(params.loc[params.param == "beta_spline_dimension", 'base'])
-        beta_spline_power = int(params.loc[params.param == "beta_spline_power", 'base'])
         knots = np.linspace(0, nobs-nobs/beta_k/2, beta_k)
         X = np.stack([power_spline(day, knots, beta_spline_power, xtrim = nobs) for day in range(nobs)])
         Xmu = np.mean(X, axis = 0)

--- a/_88_get_gamma_params.R
+++ b/_88_get_gamma_params.R
@@ -569,5 +569,5 @@ df[df$param == "logistic_k", c('base', 'distribution', 'p1', 'p2')] <- c(1, 'gam
 
 write.csv(df, "~/projects/chime_sims/data/parameters.csv")
 
-
+x = beta.parms.from.quantiles(q = c(.2,.5), p = c(.025, .975), plot = T)
 

--- a/_99_shared_functions.py
+++ b/_99_shared_functions.py
@@ -123,6 +123,7 @@ def power_spline(x, knots, n, xtrim):
         x = xtrim + 1
     spl = x - np.array(knots)
     spl[spl<0] = 0
+    spl = spl/(xtrim**n)#scaling -- xtrim is the max number of days, so the highest value that the spline could have
     return spl**n
 
 '''

--- a/data/CCH_parameters.csv
+++ b/data/CCH_parameters.csv
@@ -19,5 +19,5 @@ hosp_capacity,,constant,,,Hospital Bed Capacity
 vent_capacity,,constant,,,Ventilator Capacity
 beta_spline_dimension,5,constant,,,number of splines for beta
 beta_spline_power,1,constant,,,polynomial of the truncated power spline
-beta_spline_prior,0,norm,0,0.2,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
+beta_spline_prior,0,norm,0,10,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
 b0,4,norm,-5,2.5,"This is the intercept on the mean of the logistic. It should be large and negative such that 1-logistic(b0+XB) is close to one when X is zero, because the (1-sd) is a coef on beta"

--- a/data/Downtown_parameters.csv
+++ b/data/Downtown_parameters.csv
@@ -19,5 +19,5 @@ hosp_capacity,,constant,,,Hospital Bed Capacity
 vent_capacity,383,constant,,,Ventilator Capacity
 beta_spline_dimension,5,constant,,,number of splines for beta
 beta_spline_power,1,constant,,,polynomial of the truncated power spline
-beta_spline_prior,0,norm,0,0.2,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
+beta_spline_prior,0,norm,0,10,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
 b0,4,norm,-5,2.5,"This is the intercept on the mean of the logistic. It should be large and negative such that 1-logistic(b0+XB) is close to one when X is zero, because the (1-sd) is a coef on beta"

--- a/data/HUP_parameters.csv
+++ b/data/HUP_parameters.csv
@@ -19,5 +19,5 @@ hosp_capacity,,constant,,,Hospital Bed Capacity
 vent_capacity,196,constant,,,Ventilator Capacity
 beta_spline_dimension,5,constant,,,number of splines for beta
 beta_spline_power,1,constant,,,polynomial of the truncated power spline
-beta_spline_prior,0,norm,0,0.2,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
+beta_spline_prior,0,norm,0,10,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
 b0,4,norm,-5,2.5,"This is the intercept on the mean of the logistic. It should be large and negative such that 1-logistic(b0+XB) is close to one when X is zero, because the (1-sd) is a coef on beta"

--- a/data/LGH_parameters.csv
+++ b/data/LGH_parameters.csv
@@ -19,5 +19,5 @@ hosp_capacity,525,constant,,,Hospital Bed Capacity
 vent_capacity,131,constant,,,Ventilator Capacity
 beta_spline_dimension,5,constant,,,number of splines for beta
 beta_spline_power,1,constant,,,polynomial of the truncated power spline
-beta_spline_prior,0,norm,0,0.2,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
+beta_spline_prior,0,norm,0,10,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
 b0,4,norm,-5,2.5,"This is the intercept on the mean of the logistic. It should be large and negative such that 1-logistic(b0+XB) is close to one when X is zero, because the (1-sd) is a coef on beta"

--- a/data/MCP_parameters.csv
+++ b/data/MCP_parameters.csv
@@ -19,5 +19,5 @@ hosp_capacity,,constant,,,Hospital Bed Capacity
 vent_capacity,63,constant,,,Ventilator Capacity
 beta_spline_dimension,5,constant,,,number of splines for beta
 beta_spline_power,1,constant,,,polynomial of the truncated power spline
-beta_spline_prior,0,norm,0,0.2,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
+beta_spline_prior,0,norm,0,10,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
 b0,4,norm,-5,2.5,"This is the intercept on the mean of the logistic. It should be large and negative such that 1-logistic(b0+XB) is close to one when X is zero, because the (1-sd) is a coef on beta"

--- a/data/PAH_parameters.csv
+++ b/data/PAH_parameters.csv
@@ -19,5 +19,5 @@ hosp_capacity,,constant,,,Hospital Bed Capacity
 vent_capacity,76,constant,,,Ventilator Capacity
 beta_spline_dimension,5,constant,,,number of splines for beta
 beta_spline_power,1,constant,,,polynomial of the truncated power spline
-beta_spline_prior,0,norm,0,0.2,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
+beta_spline_prior,0,norm,0,10,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
 b0,4,norm,-5,2.5,"This is the intercept on the mean of the logistic. It should be large and negative such that 1-logistic(b0+XB) is close to one when X is zero, because the (1-sd) is a coef on beta"

--- a/data/PMC_parameters.csv
+++ b/data/PMC_parameters.csv
@@ -19,5 +19,5 @@ hosp_capacity,,constant,,,Hospital Bed Capacity
 vent_capacity,111,constant,,,Ventilator Capacity
 beta_spline_dimension,5,constant,,,number of splines for beta
 beta_spline_power,1,constant,,,polynomial of the truncated power spline
-beta_spline_prior,0,norm,0,0.2,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
+beta_spline_prior,0,norm,0,10,prior on spline terms. Variance of splines is the inverse of an L2 penalty.
 b0,4,norm,-5,2.5,"This is the intercept on the mean of the logistic. It should be large and negative such that 1-logistic(b0+XB) is close to one when X is zero, because the (1-sd) is a coef on beta"


### PR DESCRIPTION
In order to facilitate fancier stuff with splines, I've added a simple form of scaling to the power_spline function.  It takes advantage of the `xtrim` argument -- which specifies the value at which the spline gets truncated -- and divides by it.  In theory, it should work for higher-order splines, but I'm finding that behavior of quadratic splines is still a little wonky.  