### PR TITLE
Catch runtime warnings

### DIFF
--- a/_99_shared_functions.py
+++ b/_99_shared_functions.py
@@ -132,7 +132,11 @@ Plan:
 '''
 
 def logistic(L, k, x0, x):
-    return L / (1 + np.exp(-k * (x - x0)))
+    exp_term = np.exp(-k * (x - x0))
+    # Catch overflow and return nan instead of 0.0
+    if not np.isfinite(exp_term):
+        return np.nan
+    return L / (1 + exp_term)
 
 
 def qdraw(qvec, p_df):

--- a/do_all_hospitals.sh
+++ b/do_all_hospitals.sh
@@ -25,7 +25,7 @@ do
 	--reopen_cap $reopen_cap \
 	--prefix $loc \
 	-o "${loc}_flexB_novent" \
-	--ignore_vent
+	--ignore_vent 2>> errors.out &
 done
 
 # fit logistic as a backup
@@ -43,7 +43,7 @@ do
 	--reopen_cap $reopen_cap \
 	--prefix $loc \
 	-o "${loc}_logistic_novent" \
-	--ignore_vent
+	--ignore_vent 2>> errors.out &
 done
 
 # fit a version for LGH and CCH that has a downward prior, reflecting the fact that we know that there were clusters of LTC cases that won't get replicated next week:
@@ -66,7 +66,7 @@ do
 	-o "${loc}_downward_prior_novent" \
 	--forecast_change_prior_mean " -10" \
 	--forecast_change_prior_sd " 5" \
-	--ignore_vent
+	--ignore_vent 2>> errors.out &
 done
 
 


### PR DESCRIPTION
Closes #68 
- Catch the overflow in logistic fnc. Return nan to avoid parameter runaway.
- Redirect all warnings and other stderr to file `errors.out` (append-mode).