### PR TITLE
Fix reop

### DIFF
--- a/_01_GOF_sims.py
+++ b/_01_GOF_sims.py
@@ -23,11 +23,6 @@ from _02_munge_chains import SD_plot, mk_projection_tables, plt_predictive, \
 from utils import beta_from_q
 
 LET_NUMS = pd.Series(list(ascii_letters) + list(digits))
-# PARAMDIR = None
-# CENSUS_TS = None
-# PARAMS = None
-# NOBS = None
-# N_ITERS = None
 
 def get_dir_name(options):
     now = datetime.now()
@@ -585,15 +580,7 @@ def main():
                    ignore_vent = ignore_vent)
     if save_chains:
         df.to_json(path.join(f"{outdir}", "chains.json.bz2"), orient="records", lines=True)
-# df = pd.read_json("/Users/crandrew/projects/chime_sims/output/2020_05_22_14_26_42_0.0test/output/chains.json.bz2", lines = True)
-# import os
-# census_ts = pd.read_csv(f"{os.getcwd()}/data/CCH_ts.csv")
-# params = pd.read_csv(f"{os.getcwd()}/data/CCH_parameters.csv")
-# figdir = "/Users/crandrew/Desktop/"
-# prefix = ""
-# reopen_day = 100
-# reopen_cap = 0
-# reopen_speed = .05
+
     # process the output    
     burn_in_df = df.loc[(df.iter <= burn_in)]
     df = df.loc[(df.iter > burn_in)]
@@ -610,8 +597,6 @@ def main():
               as_of_days_ago = as_of_days_ago,
               census_ts = census_ts)
 
-    
-    
     ## Rt plot
     Rt_plot(df=df, 
               first_day = census_ts[census_ts.columns[0]].values[0], 

--- a/_01_GOF_sims.py
+++ b/_01_GOF_sims.py
@@ -284,7 +284,7 @@ def do_chains(n_iters,
 def main():
     # if __name__ == "__main__":
         # n_chains = 8
-        # n_iters = 3000
+        # n_iters = 300
         # penalty = .25
         # fit_penalty = False
         # sample_obs = False
@@ -297,15 +297,14 @@ def main():
         # # import parameters
         # params = pd.read_csv(path.join(f"/Users/crandrew/projects/chime_sims/data/", f"PAH_parameters.csv"), encoding = "latin")
         # flexible_beta = True
-        # fit_penalty = True
         # y_max = None
         # figdir = f"/Users/crandrew/projects/chime_sims/output/foo/"
         # outdir = f"/Users/crandrew/projects/chime_sims/output/"
-        # burn_in = 2000
+        # burn_in = 200
         # prefix = ""
         # reopen_day = 100
         # reopen_speed = .1
-        # reopen_cap = .5
+        # reopen_cap = 0.0
         
         # forecast_change_prior_mean = 0
         # forecast_change_prior_sd = -99920
@@ -586,8 +585,16 @@ def main():
                    ignore_vent = ignore_vent)
     if save_chains:
         df.to_json(path.join(f"{outdir}", "chains.json.bz2"), orient="records", lines=True)
-
-    # process the output
+# df = pd.read_json("/Users/crandrew/projects/chime_sims/output/2020_05_22_14_26_42_0.0test/output/chains.json.bz2", lines = True)
+# import os
+# census_ts = pd.read_csv(f"{os.getcwd()}/data/CCH_ts.csv")
+# params = pd.read_csv(f"{os.getcwd()}/data/CCH_parameters.csv")
+# figdir = "/Users/crandrew/Desktop/"
+# prefix = ""
+# reopen_day = 100
+# reopen_cap = 0
+# reopen_speed = .05
+    # process the output    
     burn_in_df = df.loc[(df.iter <= burn_in)]
     df = df.loc[(df.iter > burn_in)]
     
@@ -646,7 +653,6 @@ def main():
         reop = np.stack(reop)
         reopq = np.quantile(reop, [.05, .25, .5, .75, .95], axis = 0)
         qmats.append(reopq)
-
     dates = pd.date_range(f"{first_day}", periods=201, freq="d")
     fig = plt.figure()
     for i in range(len(reopen_days)):
@@ -663,8 +669,6 @@ def main():
     fig.autofmt_xdate()
     fig.savefig(path.join(f"{figdir}", f"{prefix}reopening_scenarios.pdf"))
      
-    
-
     mk_projection_tables(df, first_day, outdir)
 
     toplot = df[

--- a/_99_shared_functions.py
+++ b/_99_shared_functions.py
@@ -106,8 +106,6 @@ def sim_sir(
         # reoplist.append(reop)
         sd *= reop
         beta_t = beta * (1 - sd)
-        sdlist.append(sd)
-        betatlist.append(beta_t)
         S, E, I, R = sir(y, alpha, beta_t, gamma, nu, N)
         s.append(S)
         e.append(E)

--- a/_99_shared_functions.py
+++ b/_99_shared_functions.py
@@ -35,7 +35,9 @@ def reopenfn(day, reopen_day=60, reopen_speed=0.1, reopen_cap = .5):
         return 1.0
     else:
         val = (1 - reopen_speed) ** (day - reopen_day)
-        return val if val >= reopen_cap else reopen_cap
+        val = val if val < reopen_cap else reopen_cap
+        return val
+
 
 def reopen_wrapper(dfi, day, speed, cap):
     p_df = dfi.reset_index()   
@@ -56,7 +58,7 @@ def scale(arr, mu, sig):
     return arr
 
 
-
+import matplotlib.pyplot as plt
 # Run the SIR model forward in time
 def sim_sir(
     S,
@@ -82,8 +84,10 @@ def sim_sir(
     reopen_speed = 0.0,
     reopen_cap = 1.0,
 ):
+    print(reopen_cap)
     N = S + E + I + R
     s, e, i, r = [S], [E], [I], [R]
+    # reoplist, sdlist, betatlist = [],[] ,[]
     if len(beta_spline) > 0:
         knots = np.linspace(0, nobs-nobs/beta_k/2, beta_k)
     for day in range(n_days):
@@ -97,24 +101,24 @@ def sim_sir(
             sd = logistic(L = 1, k=1, x0 = 0, x= b0 + XB)
         else:
             sd = logistic(logistic_L, logistic_k, logistic_x0, x=day)
-        sd *= reopenfn(day, reopen_day, reopen_speed, reopen_cap)
+        reop = reopenfn(day, reopen_day, reopen_speed, reopen_cap)
+        # reop = reop if reop < reopen_cap else reopen_cap
+        # reoplist.append(reop)
+        sd *= reop
         beta_t = beta * (1 - sd)
+        sdlist.append(sd)
+        betatlist.append(beta_t)
         S, E, I, R = sir(y, alpha, beta_t, gamma, nu, N)
         s.append(S)
         e.append(E)
         i.append(I)
         r.append(R)
     s, e, i, r = np.array(s), np.array(e), np.array(i), np.array(r)
+    # plt.plot(sdlist)
+    # plt.plot(betatlist)
+    # plt.plot(reoplist)
     return s, e, i, r
 
-
-# # compute X scale factor.  first need to compute who X matrix across all days
-# nobs = 100
-# n_days = 100
-# beta_spline_power = 2
-# beta_spline = np.random.uniform(size = len(knots))
-# X = np.stack([power_spline(day, knots, beta_spline_power, xtrim = nobs) for day in range(n_days)])
-# # need to be careful with this:  apply the scaling to the new X's when predicting
 
 
 

--- a/_99_shared_functions.py
+++ b/_99_shared_functions.py
@@ -35,7 +35,7 @@ def reopenfn(day, reopen_day=60, reopen_speed=0.1, reopen_cap = .5):
         return 1.0
     else:
         val = (1 - reopen_speed) ** (day - reopen_day)
-        val = val if val < reopen_cap else reopen_cap
+        val = val if val > (1-reopen_cap) else (1-reopen_cap)
         return val
 
 
@@ -84,7 +84,6 @@ def sim_sir(
     reopen_speed = 0.0,
     reopen_cap = 1.0,
 ):
-    print(reopen_cap)
     N = S + E + I + R
     s, e, i, r = [S], [E], [I], [R]
     # reoplist, sdlist, betatlist = [],[] ,[]
@@ -102,8 +101,6 @@ def sim_sir(
         else:
             sd = logistic(logistic_L, logistic_k, logistic_x0, x=day)
         reop = reopenfn(day, reopen_day, reopen_speed, reopen_cap)
-        # reop = reop if reop < reopen_cap else reopen_cap
-        # reoplist.append(reop)
         sd *= reop
         beta_t = beta * (1 - sd)
         S, E, I, R = sir(y, alpha, beta_t, gamma, nu, N)
@@ -117,7 +114,16 @@ def sim_sir(
     # plt.plot(reoplist)
     return s, e, i, r
 
+# beta = 3
+# sd = .9
+# reopen_speed = .05
+# day = 200
+# reopen_day = 100
+# reopen_cap = 0
+# val = (1 - reopen_speed) ** (day - reopen_day)
+# val = val if val > reopen_cap else reopen_cap
 
+# beta* (1-sd*val)
 
 
 def power_spline(x, knots, n, xtrim):

--- a/old_misc/test_scaling.sh
+++ b/old_misc/test_scaling.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Set the arguments
+chains=8
+n_iters=5000
+burn_in=2000
+reopen_day=100
+reopen_speed=.05
+reopen_cap=.2
+loc='Downtown'
+
+echo $loc
+echo $chains
+python _01_GOF_sims.py -p data/"$loc"_parameters.csv -t data/"$loc"_ts.csv \
+-C $chains \
+-b \
+--penalty .25 \
+-i $n_iters \
+-B $burn_in \
+-pp \
+--reopen_day $reopen_day \
+--reopen_speed $reopen_speed \
+--reopen_cap $reopen_cap \
+--prefix $loc \
+-o "${loc}_scaledquad" \
+--ignore_vent

--- a/test_mob.sh
+++ b/test_mob.sh
@@ -1,0 +1,29 @@
+
+
+#!/bin/bash
+
+# Set the arguments
+chains=8
+n_iters=5000
+burn_in=2000
+reopen_day=100
+reopen_speed=.05
+reopen_cap=.5 
+
+
+python _01_GOF_sims.py \
+-p data/PAH_parameters.csv \
+-t data/PAH_ts.csv \
+-C $chains \
+-b \
+--penalty .06 \
+-i $n_iters \
+-B $burn_in \
+-pp \
+--reopen_day $reopen_day \
+--reopen_speed $reopen_speed \
+--reopen_cap $reopen_cap \
+-o "test" \
+--include_mobility \
+--location_string "United States, Pennsylvania, Philadelphia County"
+

--- a/test_reop.sh
+++ b/test_reop.sh
@@ -1,0 +1,29 @@
+
+
+#!/bin/bash
+
+# Set the arguments
+chains=8
+n_iters=5000
+burn_in=2000
+reopen_day=100
+reopen_speed=.05
+# reopen_cap=.5 
+
+for reopen_cap in 0.0 .2 .8 1
+do
+	python _01_GOF_sims.py \
+	-p data/CCH_parameters.csv \
+	-t data/CCH_ts.csv \
+	-C $chains \
+	-b \
+	-i $n_iters \
+	-B $burn_in \
+	-pp \
+	--reopen_day $reopen_day \
+	--reopen_speed $reopen_speed \
+	--reopen_cap $reopen_cap \
+	-o "${reopen_cap}test" \
+	--ignore_vent \
+	--save_chains 
+done

--- a/test_reop.sh
+++ b/test_reop.sh
@@ -24,6 +24,5 @@ do
 	--reopen_speed $reopen_speed \
 	--reopen_cap $reopen_cap \
 	-o "${reopen_cap}test" \
-	--ignore_vent \
-	--save_chains 
+	--ignore_vent &
 done


### PR DESCRIPTION
This script:


```

#!/bin/bash

# Set the arguments
chains=8
n_iters=5000
burn_in=2000
reopen_day=100
reopen_speed=.05
# reopen_cap=.5 

for reopen_cap in 0.0 .2 .8 1
do
	python _01_GOF_sims.py \
	-p data/CCH_parameters.csv \
	-t data/CCH_ts.csv \
	-C $chains \
	-b \
	-i $n_iters \
	-B $burn_in \
	-pp \
	--reopen_day $reopen_day \
	--reopen_speed $reopen_speed \
	--reopen_cap $reopen_cap \
	-o "${reopen_cap}test" \
	--ignore_vent &
done

```

Yields this for a cap of zero:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/13458532/82706387-74897d00-9c47-11ea-8a33-d680e4e3d156.png">

This for a cap of .2:

<img width="848" alt="image" src="https://user-images.githubusercontent.com/13458532/82706409-810dd580-9c47-11ea-893d-2aebc9859b2c.png">

this for a cap of .8:
<img width="835" alt="image" src="https://user-images.githubusercontent.com/13458532/82706434-9256e200-9c47-11ea-8c48-03cdbbaf8689.png">

and this for a cap of 1:

<img width="824" alt="image" src="https://user-images.githubusercontent.com/13458532/82706466-a6024880-9c47-11ea-9466-5428b1760889.png">

This is in response to #72 